### PR TITLE
Fix/yamaguchi/data get

### DIFF
--- a/app/firebase/data_get.js
+++ b/app/firebase/data_get.js
@@ -11,10 +11,19 @@ if (admin.apps.length === 0) { //2重起動防止
   });
 }
 
-exports.data_get = async function(category, doc) {
+exports.data_get = async function(post) {
   var data;
   var db = admin.database();
-  var ref = db.ref(category + doc.doc);
+  var ref;
+
+  if(post.category === "users"){
+    ref = db.ref(post.category + "/" + post.id);
+    console.log(post.doc);
+  }
+  if(post.category === "posts"){
+    ref = db.ref(post.category);
+  }
+
   await ref.once('value', (snapshot) => {
     data = snapshot.val();
   });

--- a/app/routes/GetPost.js
+++ b/app/routes/GetPost.js
@@ -11,10 +11,11 @@ module.exports = router;
 
 router.post('/', async function(req, res, next) {
 	const post = {
-    doc: req.body.doc
+    id: req.body.userid,
+    category: "posts"
 	}
-
-  const data = await get.data_get("posts/", post);
+  console.log(typeof(post.userid));
+  const data = await get.data_get(post);
   console.log(data);
   res.status(200).json(data);
 });

--- a/app/routes/GetProfile.js
+++ b/app/routes/GetProfile.js
@@ -10,11 +10,12 @@ router.get('/', function(req, res, next) {
 module.exports = router;
 
 router.post('/', async function(req, res, next) {
-	const doc = {
-    doc: req.body.doc
+	const post = {
+    id: req.body.userid,
+    category: "users"
 	}
 
-  const data = await get.data_get("users/", doc);
+  const data = await get.data_get(post);
   console.log(data);
   res.status(200).json(data);
 });


### PR DESCRIPTION
- data_get.jsを実行する際に、投稿データかユーザーデータか識別する必要が出たため、識別するためのプロパティであるcategoryを、data_getへ送るデータとして追加
- data_get.jsを実行する際に、投稿データかユーザーデータかで処理を分ける必要が出たため、categoryプロパティを用いて処理を分岐
- data_get.jsにて投稿データの取得を試みた際に、DB内の投稿データを全て取得するように変更